### PR TITLE
chore(apps): handle optfix in a better (Amy) way

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,9 +18,9 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
-    /ctx/109-optfix.sh && \
-    /ctx/util/optfix.sh && \
+    /ctx/109-opt_prep.sh && \
     /ctx/110-desktop_packages.sh && \
+    /ctx/util/optfix.sh && \
     /ctx/util/finalize_layer.sh
     
 RUN bootc container lint
@@ -48,9 +48,9 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
-    /ctx/109-optfix.sh && \
-    /ctx/util/optfix.sh && \
+    /ctx/109-opt_prep.sh && \
     /ctx/110-desktop_packages.sh && \
+    /ctx/util/optfix.sh && \
     /ctx/util/finalize_layer.sh
     
 RUN bootc container lint

--- a/build_files/109-opt_prep.sh
+++ b/build_files/109-opt_prep.sh
@@ -4,6 +4,6 @@ echo "::group:: ===$(basename "$0")==="
 
 set -ouex pipefail
 
-mkdir -p /usr/lib/opt/brave
+mkdir -p /var/opt
 
 echo "::endgroup::"

--- a/build_files/util/optfix.sh
+++ b/build_files/util/optfix.sh
@@ -1,29 +1,17 @@
 #!/usr/bin/env bash
 
 # Stolen from https://github.com/blue-build/modules/blob/main/modules/dnf/optfix.sh
+# Later adapted to https://github.com/astrovm/amyos/blob/main/build_files/fix-opt.sh
+
+echo "::group:: ===$(basename "$0")==="
 
 set -euo pipefail
 
-SOURCE_DIR="/usr/lib/opt"
-TARGET_DIR="/var/opt"
-
-# Ensure the target directory exists
-mkdir -p "$TARGET_DIR"
-
-# Loop through directories in the source directory
-for dir in "$SOURCE_DIR/"*/; do
-  if [ -d "$dir" ]; then
-    # Get the base name of the directory
-    dir_name=$(basename "$dir")
-    
-    # Check if the symlink already exists in the target directory
-    if [ -L "$TARGET_DIR/$dir_name" ]; then
-      echo "Symlink already exists for $dir_name, skipping."
-      continue
-    fi
-    
-    # Create the symlink
-    ln -s "$dir" "$TARGET_DIR/$dir_name"
-    echo "Created symlink for $dir_name"
-  fi
+for dir in /var/opt/*/; do
+  [ -d "$dir" ] || continue
+  dirname=$(basename "$dir")
+  mv "$dir" "/usr/lib/opt/$dirname"
+  echo "L+ /var/opt/$dirname - - - - /usr/lib/opt/$dirname" >>/usr/lib/tmpfiles.d/geekos-optfix.conf
 done
+
+echo "::endgroup::"


### PR DESCRIPTION
Different way of dealing with programs insisting on installation to `/opt`. Thanks to https://github.com/astrovm/amyos.