### PR TITLE
fix(pkg): use copr for ghostty install, add hardinfo2 depends

### DIFF
--- a/build_files/090-repos.sh
+++ b/build_files/090-repos.sh
@@ -18,6 +18,7 @@ dnf5 -yq config-manager setopt brave-browser.enabled=false
 # copr repos
 copr_repos=(
     "ilyaz/LACT"
+    "scottames/ghostty"
 )
 
 # Enable defined copr repos

--- a/build_files/110-desktop_packages.sh
+++ b/build_files/110-desktop_packages.sh
@@ -7,11 +7,13 @@ set -ouex pipefail
 packages=(
   "code::code"
   "brave-browser::brave-browser"
+  "copr:copr.fedorainfracloud.org:scottames:ghostty::ghostty"
   "fedora::hardinfo2"
+  "fedora::iperf3"
   "fedora::solaar"
+  "fedora::sysbench"
   "fedora::wireshark"
   "terra::coolercontrol"
-  "terra::ghostty"
   "terra::mpv-nightly"
 )
 


### PR DESCRIPTION
This may resolve the shell integration issue in recent `ghostty` release